### PR TITLE
Fix small regex mistakes, NE, OR, and VA

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Below is a callback function for validating a dl field using CodeIgniter's `form
       $dlformat = array(
         'AL'=>"^[0-9]{1,7}$", //1-7Numbers
         'AK'=>"^[0-9]{1,7}$", //1-7Numbers
-        'AZ'=>"(^[a-zA-Z]{1}[0-9]{8}$)|(^[a-zA-Z]{2}[0-9]{2,5}$)|(^[0-9]{9}$)", //1Alpha+1-8Numeric or 2Alpha+2-5Numeric or 9Numeric
+        'AZ'=>"(^[a-zA-Z]{1}[0-9]{1,8}$)|(^[a-zA-Z]{2}[0-9]{2,5}$)|(^[0-9]{9}$)", //1Alpha+1-8Numeric or 2Alpha+2-5Numeric or 9Numeric
         'AR'=>"^[0-9]{4,9}$", //4-9Numeric
         'CA'=>"^[a-zA-Z]{1}[0-9]{7}$", //1Alpha+7Numeric
         'CO'=>"(^[0-9]{9}$)|(^[a-zA-Z]{1}[0-9]{3,6}$)|(^[a-zA-Z]{2}[0-9]{2,5}$)", //9Numeric or 1Alpha+3-6Numeric or 2Alpha+2-5Numeric
@@ -35,7 +35,7 @@ Below is a callback function for validating a dl field using CodeIgniter's `form
         'ID'=>"(^[a-zA-Z]{2}[0-9]{6}[a-zA-Z]{1}$)|(^[0-9]{9}$)", //2Alpha+6Numeric+1Alpha or 9Numeric
         'IL'=>"^[a-zA-Z]{1}[0-9]{11,12}$", //1Alpha+11-12Numeric
         'IN'=>"(^[a-zA-Z]{1}[0-9]{9}$)|(^[0-9]{9,10}$)", //1Alpha+9Numeric or 9-10Numeric
-        'IA'=>"^[0-9]{9}|([0-9]{3}[a-zA-Z]{2}[0-9]{4}$)", //9Numeric or 3Numeric+2Alpha+4Numeric
+        'IA'=>"(^[0-9]{9}$)|([0-9]{3}[a-zA-Z]{2}[0-9]{4}$)", //9Numeric or 3Numeric+2Alpha+4Numeric
         'KS'=>"(^([a-zA-Z]{1}[0-9]{1}){2}[a-zA-Z]{1}$)|(^[a-zA-Z]{1}[0-9]{8}$)|(^[0-9]{9}$)", //1Alpha+1Numeric+1Alpha+1Numeric+1Alpha or 1Alpha+8Numeric or 9Numeric
         'KY'=>"(^[a-zA_Z]{1}[0-9]{8,9}$)|(^[0-9]{9}$)", //1Alpha+8-9Numeric or 9Numeric
         'LA'=>"^[0-9]{1,9}$", //1-9Numeric
@@ -47,7 +47,7 @@ Below is a callback function for validating a dl field using CodeIgniter's `form
         'MS'=>"^[0-9]{9}$", //9Numeric
         'MO'=>"(^[a-zA-Z]{1}[0-9]{5,9}$)|(^[a-zA-Z]{1}[0-9]{6}[R]{1}$)|(^[0-9]{8}[a-zA-Z]{2}$)|(^[0-9]{9}[a-zA-Z]{1}$)|(^[0-9]{9}$)", //1Alpha+5-9Numeric or 1Alpha+6Numeric+R or 8Numeric+2Alpha or 9Numeric+1Alpha or 9Numeric
         'MT'=>"(^[a-zA-Z]{1}[0-9]{8}$)|(^[0-9]{13}$)|(^[0-9]{9}$)|(^[0-9]{14}$)", //1Alpha+8Numeric or 13Numeric or 9Numeric or 14Numeric
-        'NE'=>"^[0-9]{1,7}$", //1-7Numeric
+        'NE'=>"^[a-zA-Z]{1}[0-9]{3,8}$", //1Alpha+3-8Numeric
         'NV'=>"(^[0-9]{9,10}$)|(^[0-9]{12}$)|(^[X]{1}[0-9]{8}$)", //9Numeric or 10Numeric or 12Numeric or X+8Numeric
         'NH'=>"^[0-9]{2}[a-zA-Z]{3}[0-9]{5}$", //2Numeric+3Alpha+5Numeric
         'NJ'=>"^[a-zA-Z]{1}[0-9]{14}$", //1Alpha+14Numeric
@@ -57,7 +57,7 @@ Below is a callback function for validating a dl field using CodeIgniter's `form
         'ND'=>"(^[a-zA-Z]{3}[0-9]{6}$)|(^[0-9]{9}$)", //3Alpha+6Numeric or 9Numeric
         'OH'=>"(^[a-zA-Z]{1}[0-9]{4,8}$)|(^[a-zA-Z]{2}[0-9]{3,7}$)|(^[0-9]{8}$)", //1Alpha+4-8Numeric or 2Alpha+3-7Numeric or 8Numeric
         'OK'=>"(^[a-zA-Z]{1}[0-9]{9}$)|(^[0-9]{9}$)", //1Alpha+9Numeric or 9Numeric
-        'OR'=>"^[0-9]{1,9}$", //1-9Numeric
+        'OR'=>"(^[0-9]{1,9}$)|(^[a-zA-Z]{1}[0-9]{6}$)|(^[a-zA-Z]{2}[0-9]{5}$)", //1-9Numeric or 1Alpha+6Numeric or 2Alpha+5Numeric
         'PA'=>"^[0-9]{8}$", //8Numeric
         'RI'=>"^([0-9]{7}$)|(^[a-zA-Z]{1}[0-9]{6}$)", //7Numeric or 1Alpha+6Numeric
         'SC'=>"^[0-9]{5,11}$", //5-11Numeric
@@ -66,7 +66,7 @@ Below is a callback function for validating a dl field using CodeIgniter's `form
         'TX'=>"^[0-9]{7,8}$", //7-8Numeric
         'UT'=>"^[0-9]{4,10}$", //4-10Numeric
         'VT'=>"(^[0-9]{8}$)|(^[0-9]{7}[A]$)", //8Numeric or 7Numeric+A
-        'VA'=>"(^[a-zA-Z]{1}[0-9]{9,11}$)|(^[0-9]{9}$)", //1Alpha+9Numeric or 1Alpha+10Numeric or 1Alpha+11Numeric or 9Numeric
+        'VA'=>"(^[a-zA-Z]{1}[0-9]{8}$)|(^[0-9]{9}$)|(^[0-9]{12}$))", //1Alpha+8Numeric or 9Numeric or 12Numeric
         'WA'=>"^(?=.{12}$)[a-zA-Z]{1,7}[a-zA-Z0-9\*]{4,11}$", //1-7Alpha+any combination of Alpha, Numeric, or * for a total of 12 characters
         'WV'=>"(^[0-9]{7}$)|(^[a-zA-Z]{1,2}[0-9]{5,6}$)", //7Numeric or 1-2Alpha+5-6Numeric
         'WI'=>"^[a-zA-Z]{1}[0-9]{13}$", //1Alpha+13Numeric


### PR DESCRIPTION
This fixes some minor regex mistakes with AZ and IA, and updates NE, OR, and VA to align with the following document.

http://adr-inc.com/PDFs/State_DLFormats.pdf
