### PR TITLE
Update regex.json

### DIFF
--- a/regex.json
+++ b/regex.json
@@ -327,8 +327,9 @@
     ]
   },
   "VA": {
-    "rule": "(^[A-Z]{1}[0-9]{9,11}$)|(^[0-9]{9}$)",
+    "rule": "(^[A-Z]{1}[0-9]{8,11}$)|(^[0-9]{9}$)",
     "description": [
+      "1 Alpha + 8 Numeric",
       "1 Alpha + 9 Numeric",
       "1 Alpha + 10 Numeric",
       "1 Alpha + 11 Numeric",

--- a/test/features/json.feature
+++ b/test/features/json.feature
@@ -559,7 +559,7 @@ Feature: Valid Regex Rules
             | VA    | A123456789           | TRUE   |
             | VA    | A1234567890          | TRUE   |
             | VA    | A12345678901         | TRUE   |
-            | VA    | A12345678            | FALSE  |
+            | VA    | A12345678            | TRUE   |
             | VA    | A123456789012        | FALSE  |
             | VA    | 123456789A           | FALSE  |
             | VA    | AB123456789          | FALSE  |


### PR DESCRIPTION
Small addition to the VA DL format.  
I have a valid VA license the its format is **1 Alpha + 8 Numeric**.  I have also verified this with about 10 other VA license holders.   

Below links also state 1+ 8 is valid:
https://www.sambasafety.com/resources/State_DLFormats.pdf
http://www.dmv.state.va.us/drivers/#newlook.asp
http://www.dmv.state.va.us/general/news/pdf/barcode_calibration.pdf

I also sent an email to https://ntsi.com/drivers-license-format/ since that's where you obtained your formats from.  