### PR TITLE
AL has "descriptions" inconsistent with other states having "description"

### DIFF
--- a/regex.json
+++ b/regex.json
@@ -1,7 +1,7 @@
 {
   "AL": {
     "rule": "^[0-9]{1,7}$",
-    "descriptions": [
+    "description": [
       "1-7 Numeric"
     ]
   },


### PR DESCRIPTION
Just dropped the "s" for consistency. 